### PR TITLE
Fix variable naming issue

### DIFF
--- a/src/neo_omnidrive_node.cpp
+++ b/src/neo_omnidrive_node.cpp
@@ -379,7 +379,7 @@ private:
         odom_tf.header.frame_id = robot_namespace + m_odom_frame;
         odom_tf.child_frame_id = robot_namespace + m_base_frame;
       } else {
-        odom_f.header.frame_id = m_odom_frame;
+        odom_tf.header.frame_id = m_odom_frame;
         odom_tf.child_frame_id = m_base_frame;
       }
       // compose data container


### PR DESCRIPTION
// Bug Fix: Issue with undeclared 'odom_f' variable
// neo_kinematics_omnidrive2/src/neo_omnidrive_node.cpp:382
// Fix: Corrected variable name to 'odom_tf' for consistency and resolved scope issue.
// This resolves the compilation error and ensures proper use of the 'odom_tf' variable.